### PR TITLE
Remove extra ampersands from query strings.

### DIFF
--- a/src/PHPPagination/Pagination.php
+++ b/src/PHPPagination/Pagination.php
@@ -574,6 +574,8 @@ class Pagination
             $url_separator = (strpos($url, '?') !== false) ? '&' : '?';
 
             $url .= $url_separator . http_build_query($query_strings);
+
+            $url = trim($url, '&');
         }
 
         if ($this->fragment_query_string) {


### PR DESCRIPTION
Fix error generate by libxml_get_errors() with new DOMDocument();

Remove extra ampersands like:

mydomain.com/any?page=1&